### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ lspconfig.tsserver.setup({
       )
     end,
   },
-}))
+})
 ```
 
 [screenshot]: https://raw.githubusercontent.com/davidosomething/format-ts-errors.nvim/meta/screenshot.png


### PR DESCRIPTION
It appears that there was one parenthesis too many in the lsp-config example.